### PR TITLE
[JENKINS-66740] Fix credentials permissions checks

### DIFF
--- a/src/main/resources/hudson/plugins/blazemeter/BlazemeterCredentialsBAImpl/credentials.jelly
+++ b/src/main/resources/hudson/plugins/blazemeter/BlazemeterCredentialsBAImpl/credentials.jelly
@@ -13,60 +13,19 @@
  limitations under the License.
 -->
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+  <f:entry title="${%API Key Id}" field="username">
+    <f:textbox/>
+  </f:entry>
+  <f:entry title="${%API Key Secret}" field="password">
+    <f:password/>
+  </f:entry>
 
-  <j:if test="${descriptor.isPrivilegedUser()}">
-
-      <f:entry title="${%API Key Id}" field="username">
-        <f:textbox/>
-      </f:entry>
-      <f:entry title="${%API Key Secret}" field="password">
-        <f:password/>
-      </f:entry>
-
-      <st:include page="id-and-description" class="${descriptor.clazz}"/>
-      <f:entry>
-        <f:validateButton
+  <st:include page="id-and-description" class="${descriptor.clazz}"/>
+  <f:entry>
+    <f:validateButton
             title="${%Test BlazeMeter credentials}"
             progress="${%Validating BlazeMeter credentials}"
             method="validate"
             with="username,password"/>
-      </f:entry>
-
-  </j:if>
-
-
-
-  <j:if test="${!descriptor.isPrivilegedUser()}">
-    <h1>You don't have required privileges to add/update credentials.</h1>
-    <script>
-    
-        // Removed OK or Save button for rest of the users
-        let btnOK = document._getElementsByXPath("//button[text()='OK']")[0];
-        if (!btnOK) {
-            var timer = setInterval(function() {
-                let btnSave = document._getElementsByXPath("//button[text()='Save']")[0];
-                if (btnSave) {
-                    btnSave.remove();
-                    clearInterval(timer);
-                }
-            }, 100);
-        } else {
-            btnOK.remove();
-        }
-
-        // Removed delete button
-        let btnDelete = document._getElementsByXPath("//a[@title='Delete']")[0];
-        if (btnDelete) {
-            btnDelete.remove();
-        }
-
-        // Removed Label and Credentials drop-down 
-        let labelKind = document._getElementsByXPath("//div[contains(text(),'Kind')]")[0];
-        let credentialsTypeSelectBox = document.querySelector("select");
-        labelKind.remove();
-        credentialsTypeSelectBox.remove();
-    </script>
-  </j:if>
-
-
+  </f:entry>
 </j:jelly>


### PR DESCRIPTION
Fixes [JENKINS-66740](https://issues.jenkins.io/browse/JENKINS-66740) / https://github.com/Blazemeter/blazemeter-jenkins-plugin/issues/89.

* Use `@AncestorInPath` and `AccessControlled` to do a smart check based on the context
* Remove the jelly part that was preventing from creating also other types of credentials.