### PR TITLE
TT-3886 Allow Blazemeter plugin to run on remote Jenkins agents 

### DIFF
--- a/src/main/java/hudson/plugins/blazemeter/PerformanceBuilder.java
+++ b/src/main/java/hudson/plugins/blazemeter/PerformanceBuilder.java
@@ -325,7 +325,7 @@ public class PerformanceBuilder extends Builder implements SimpleBuildStep, Seri
         timer.scheduleAtFixedRate(reportUrlTask, 20 * 1000, 10 * 1000);
         Result result = Result.SUCCESS;
         try {
-            result = channel.call(bzmBuild);
+            result = bzmBuild.call();
             run.setResult(result);
         } catch (InterruptedException e) {
             LOGGER.warning("Build has been aborted");


### PR DESCRIPTION
https://perforce.atlassian.net/browse/TT-3886

This PR contains changes to allow the Blazemeter plugin to run on remote Jenkins agents.  This is achieved by:

- Using a BZM logger that utilizes the Jenkins logger and avoiding the creation of a new log file.
- Use the MasterToSlaveCallable as a base class for BzmBuild