### PR TITLE
TT-4354: BlazeMeter Jenkins plugin fails to find file(s) on remote agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v4.24 - 16-09-2024
+
+- `FIXED` - Fixed TT-4354: BlazeMeter Jenkins plugin fails to find file(s) on remote agents
+
 ### v4.23 - 21-05-2024
 
 - `FIXED` - Fixed TT-3886 - Unable to run the test via Jenkins plugin pipeline on remote agents

--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
                 <plugin><!-- Can be removed again when required core is updated to 1.428+ -->
                     <groupId>com.cloudbees</groupId>
                     <artifactId>maven-license-plugin</artifactId>
-                    <version>1.3</version>
+                    <version>1.10</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
As per the existing code, it looks like Jenkins plugin is not capable of accessing files (Main or Additional) on remote agents. In the code, we're using `File` object instead of `FilePath` which as per Jenkins documentation is capable to work with files on the remote agent or controllers.
This PR contains fix for both Main and additional files.

Jenkins documentation: https://javadoc.jenkins.io/hudson/FilePath.html
Jira ticket: https://perforce.atlassian.net/browse/TT-4354