### PR TITLE
MOB-38674 Upgrade blazemeter-api-client to 1.23 in order to fix issue with HTTP connections not properly being closed and starving connection pool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>com.blazemeter</groupId>
             <artifactId>blazemeter-api-client</artifactId>
-            <version>1.22</version>
+            <version>1.23</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
https://perforce.atlassian.net/browse/MOB-38674

Updates the `com.blazemeter.blazemeter-api-client` version to 1.23 in order to bring in updates to the OkHTTP client library from the following PR - https://github.com/Blazemeter/blazemeter-api-client/pull/131